### PR TITLE
Fixed problem with ismrmrd header string

### DIFF
--- a/ismrmrd/hdf5.py
+++ b/ismrmrd/hdf5.py
@@ -180,7 +180,7 @@ class Dataset(object):
         # create the dataset if needed
         self._file.require_group(self._dataset_name)
 
-        dset = self._dataset.require_dataset('xml',shape=(1,), dtype=h5py.special_dtype(vlen=str))
+        dset = self._dataset.require_dataset('xml',shape=(1,), dtype=h5py.special_dtype(vlen=bytes))
         dset[0] = xmlstring
 
     def number_of_acquisitions(self):


### PR DESCRIPTION
This change is necessary for the xml string to be writen in H5T_CSET_ASCII char set, otherwise it's saved as H5T_CSET_UTF8, which leads to error when passed to gadgetron.